### PR TITLE
Remove transition if duration is 0 to fix overlapping labels

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -506,8 +506,7 @@ const BarRankChart = Vizabi.Component.extend("barrankchart", {
       }
 
       if (force || bar.changedIndex || presentationModeChanged) {
-        bar.self
-          .transition().duration(duration).ease(d3.easeLinear)
+        (duration ? bar.self.transition().duration(duration).ease(d3.easeLinear) : bar.self)
           .attr('transform', `translate(0, ${this._getBarPosition(bar.index)})`);
       }
     });


### PR DESCRIPTION
https://github.com/Gapminder/vizabi-website/issues/47