### PR TITLE
Fix bars transition on timeslider click

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -506,6 +506,7 @@ const BarRankChart = Vizabi.Component.extend("barrankchart", {
       }
 
       if (force || bar.changedIndex || presentationModeChanged) {
+        !duration && bar.self.interrupt();
         (duration ? bar.self.transition().duration(duration).ease(d3.easeLinear) : bar.self)
           .attr('transform', `translate(0, ${this._getBarPosition(bar.index)})`);
       }


### PR DESCRIPTION
https://github.com/vizabi/vizabi/issues/2783

Interrupt bars position transition to prevent situation when timeslider is clicked, we change bars position immediately and then transition ends and breaks everything